### PR TITLE
[AI] Fix CI failures: PR: Copy/cut entire line if nothing is selected (Editor)

### DIFF
--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -438,7 +438,8 @@ class TextEditBaseWidget(
             return
         cursor.movePosition(QTextCursor.PreviousCharacter,
                             QTextCursor.KeepAnchor)
-        text = to_text_string(cursor.selectedText())
+        selected_text = to_text_string(cursor.selectedText()).rstrip()
+QApplication.clipboard().setText(selected_text)
         if text in (')', ']', '}'):
             forward = False
         elif text in ('(', '[', '{'):
@@ -852,7 +853,8 @@ class TextEditBaseWidget(
             return
 
         # ------ Move text
-        sel_text = to_text_string(cursor.selectedText())
+        sel_selected_text = to_text_string(cursor.selectedText()).rstrip()
+QApplication.clipboard().setText(selected_text)
         cursor.removeSelectedText()
 
         if after_current_line:

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -480,6 +480,8 @@ class TextEditBaseWidget(
         """
         if self.get_selected_text():
             QApplication.clipboard().setText(self.get_selected_text())
+        elif self.get_current_line():
+            QApplication.clipboard().setText(self.get_current_line())
 
     def toPlainText(self):
         """

--- a/spyder/plugins/editor/widgets/base.py
+++ b/spyder/plugins/editor/widgets/base.py
@@ -482,8 +482,7 @@ class TextEditBaseWidget(
             QApplication.clipboard().setText(self.get_selected_text())
         else:
             cursor = self.select_current_line_and_sep(set_cursor=False)
-            text = to_text_string(cursor.selectedText())
-            QApplication.clipboard().setText(text)
+            QApplication.clipboard().setText(self.get_selected_text(cursor))
 
     def toPlainText(self):
         """

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1950,24 +1950,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         """Reimplement cut to signal listeners about changes on the text."""
         has_selected_text = self.has_selected_text()
         if not has_selected_text:
-            # If no text is selected, the entire line will be selected and cut
-            cursor = self.textCursor()
-            # Do selection manually so the newline at the end of the line is selected
-            # using cursor.select(QTextCursor.BlockUnderCursor) selects previous newline
-            cursor.movePosition(QTextCursor.StartOfBlock, QTextCursor.MoveAnchor)
-            if not cursor.movePosition(QTextCursor.NextBlock, QTextCursor.KeepAnchor):
-                # if there is no next Block, we select the previous newline
-                if not cursor.movePosition(QTextCursor.PreviousBlock, QTextCursor.MoveAnchor):
-                    # if there is no previous block, we can select the current line
-                    # this is the 1-line file case
-                    cursor.select(QTextCursor.BlockUnderCursor)
-                else:
-                    # There is a previous block
-                    cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.MoveAnchor)
-                    cursor.movePosition(QTextCursor.NextBlock, QTextCursor.KeepAnchor)
-                    cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
-
-            self.setTextCursor(cursor)
+            self.select_current_line_and_sep()
 
         start, end = self.get_selection_start_end()
         self.sig_will_remove_selection.emit(start, end)

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1952,7 +1952,7 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         if not has_selected_text:
             # If no text is selected, the entire line will be selected and cut
             cursor = self.textCursor()
-            cursor.select(QTextCursor.LineUnderCursor)
+            cursor.select(QTextCursor.BlockUnderCursor)
             self.setTextCursor(cursor)
 
         start, end = self.get_selection_start_end()

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1952,7 +1952,21 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         if not has_selected_text:
             # If no text is selected, the entire line will be selected and cut
             cursor = self.textCursor()
-            cursor.select(QTextCursor.BlockUnderCursor)
+            # Do selection manually so the newline at the end of the line is selected
+            # using cursor.select(QTextCursor.BlockUnderCursor) selects previous newline
+            cursor.movePosition(QTextCursor.StartOfBlock, QTextCursor.MoveAnchor)
+            if not cursor.movePosition(QTextCursor.NextBlock, QTextCursor.KeepAnchor):
+                # if there is no next Block, we select the previous newline
+                if not cursor.movePosition(QTextCursor.PreviousBlock, QTextCursor.MoveAnchor):
+                    # if there is no previous block, we can select the current line
+                    # this is the 1-line file case
+                    cursor.select(QTextCursor.BlockUnderCursor)
+                else:
+                    # There is a previous block
+                    cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.MoveAnchor)
+                    cursor.movePosition(QTextCursor.NextBlock, QTextCursor.KeepAnchor)
+                    cursor.movePosition(QTextCursor.EndOfBlock, QTextCursor.KeepAnchor)
+
             self.setTextCursor(cursor)
 
         start, end = self.get_selection_start_end()

--- a/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
+++ b/spyder/plugins/editor/widgets/codeeditor/codeeditor.py
@@ -1950,7 +1950,11 @@ class CodeEditor(LSPMixin, TextEditBaseWidget):
         """Reimplement cut to signal listeners about changes on the text."""
         has_selected_text = self.has_selected_text()
         if not has_selected_text:
-            return
+            # If no text is selected, the entire line will be selected and cut
+            cursor = self.textCursor()
+            cursor.select(QTextCursor.LineUnderCursor)
+            self.setTextCursor(cursor)
+
         start, end = self.get_selection_start_end()
         self.sig_will_remove_selection.emit(start, end)
         self.sig_delete_requested.emit()


### PR DESCRIPTION
This pull request contains changes suggested by AI to address CI failures in `https://github.com/spyder-ide/spyder/pull/22480`.

### Explanation:
The test failures are due to an incorrect assumption about the QTextCursor's behavior, specifying the "Position '59' out of range" error. This indicates that the code attempts to manipulate or query the text cursor at an invalid position. The discrepancies are especially apparent when selecting blocks for copy/cut actions, and the error recurs across different platforms and setups.
