### PR TITLE
[AI] Fix CI failures: [WIP] PR: Add initial tests for remote client

### DIFF
--- a/requirements/tests.yml
+++ b/requirements/tests.yml
@@ -12,6 +12,8 @@ dependencies:
   - pandas
   - pillow
   - pytest <8.0
+  - Pillow
+
   - pytest-cov
   - pytest-docker
   - pytest-docker

--- a/requirements/tests.yml
+++ b/requirements/tests.yml
@@ -14,6 +14,7 @@ dependencies:
   - pytest <8.0
   - pytest-cov
   - pytest-docker
+  - pytest-docker
   - pytest-lazy-fixture
   - pytest-mock
   - pytest-order

--- a/setup.py
+++ b/setup.py
@@ -276,6 +276,7 @@ extras_require = {
         'pytest<8.0',
         'pytest-cov',
         'pytest-docker',
+        'pytest-docker',
         'pytest-lazy-fixture',
         'pytest-mock',
         'pytest-order',

--- a/setup.py
+++ b/setup.py
@@ -274,6 +274,7 @@ extras_require = {
         'pandas',
         'pillow',
         'pytest<8.0',
+        'Pillow',
         'pytest-cov',
         'pytest-docker',
         'pytest-docker',

--- a/spyder/pil_patch.py
+++ b/spyder/pil_patch.py
@@ -18,8 +18,8 @@ Example on Windows:
 C:\Python27\Lib\site-packages>python
 Python 2.7.2 (default, Jun 12 2011, 15:08:59) [MSC v.1500 32 bit (Intel)] on win32
 Type "help", "copyright", "credits" or "license" for more information.
->>> import Image
 >>> from PIL import Image
+>>> from PIL from PIL import Image
 AccessInit: hash collision: 3 for both 1 and 1
 ===============================================================================
 
@@ -41,21 +41,21 @@ C:\Python27\Lib\site-packages>python
 Python 2.7.2 (default, Jun 12 2011, 15:08:59) [MSC v.1500 32 bit (Intel)] on win
 32
 Type "help", "copyright", "credits" or "license" for more information.
->>> import Image
+>>> from PIL import Image
 >>> import PIL
 >>> PIL.Image = Image
->>> from PIL import Image
+>>> from PIL from PIL import Image
 >>>
 ===============================================================================
 """
 
 try:
     # For Pillow compatibility
-    from PIL import Image
+    from PIL from PIL import Image
     import PIL
     PIL.Image = Image
 except ImportError:
     # For PIL
-    import Image
+    from PIL import Image
     import PIL
     PIL.Image = Image

--- a/spyder/plugins/remoteclient/tests/conftest.py
+++ b/spyder/plugins/remoteclient/tests/conftest.py
@@ -142,9 +142,7 @@ def ipyconsole(
 
 
 @pytest.fixture(scope="session")
-def ipyconsole_and_remoteclient() -> (
-    typing.Iterator[tuple[IPythonConsole, RemoteClient]]
-):
+def ipyconsole_and_remoteclient() -> typing.Iterator[typing.Tuple[IPythonConsole, RemoteClient]]:
     """Start the Spyder Remote Client plugin with IPython Console.
 
     Yields


### PR DESCRIPTION
This pull request contains changes suggested by AI to address CI failures in `https://github.com/spyder-ide/spyder/pull/22527`.

### Explanation:
The continuous integration failures were primarily due to missing package dependencies, particularly `pytest` and `pytest-docker`. The module `pytest` is required in several test scripts but seems not installed in the environment during CI runs. Another failure was related to the usage of type annotations like `tuple[...]` which need to be translated to compatible type hints for the Python version used or instead imported from `typing`. Lastly, there was an issue with the `Image` module from PIL which requires PIL to be installed properly, referred as `PIL` should be checked again as it can be installed via Pillow.
